### PR TITLE
Fix logic to set the value of special flags (like log-level)

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"time"
 
+	"github.com/symfony-cli/terminal"
 	. "gopkg.in/check.v1"
 )
 
@@ -220,6 +221,25 @@ func (cs *ContextSuite) TestContext_Set(c *C) {
 
 	ctx.Set("int", "1")
 	c.Assert(ctx.Int("int"), Equals, 1)
+}
+
+func (cs *ContextSuite) TestContext_Set_AppFlags(c *C) {
+	defer terminal.SetLogLevel(1)
+
+	app := &Application{
+		Commands: []*Command{
+			&Command{
+				Name: "foo",
+				Action: func(ctx *Context) error {
+					err := ctx.Set("log-level", "4")
+					c.Assert(err, IsNil)
+
+					return nil
+				},
+			},
+		},
+	}
+	app.Run([]string{"cmd", "foo"})
 }
 
 func (cs *ContextSuite) TestContext_Lineage(c *C) {


### PR DESCRIPTION
With the previous code, `Context.IsSet("log-level")` returns `true`, but `Context.Set("log-level", 4)` doesn't find the flag and returns an error.
My proposal is to use the same logic for both functions, which fixes the `Set` call.

Also, I removed part of the `Context.IsSet()` function. It seems dead code as in any cases it will return `false`.