### PR TITLE
refacto: allow autocompletion templates to be overridden

### DIFF
--- a/completion_installer.go
+++ b/completion_installer.go
@@ -16,10 +16,10 @@ import (
 	"github.com/symfony-cli/terminal"
 )
 
-// completionTemplates holds our shell completions templates.
+// CompletionTemplates holds our shell completions templates.
 //
 //go:embed resources/completion.*
-var completionTemplates embed.FS
+var CompletionTemplates embed.FS
 
 var shellAutoCompleteInstallCommand = &Command{
 	Category: "self",
@@ -110,7 +110,7 @@ Add this to the end of your shell configuration file (e.g. <info>"{{ call .RcFil
 			shell = guessShell()
 		}
 
-		templates, err := template.ParseFS(completionTemplates, "resources/*")
+		templates, err := template.ParseFS(CompletionTemplates, "resources/*")
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/resources/completion.bash
+++ b/resources/completion.bash
@@ -18,41 +18,7 @@
 # Bash completions for the CLI binary
 #
 # References:
-#   - https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Console/Resources/completion.bash
 #   - https://github.com/posener/complete/blob/master/install/bash.go
-#   - https://github.com/scop/bash-completion/blob/master/completions/sudo
 #
 
-# this wrapper function allows us to let Symfony knows how to call the
-# `bin/console` using the Symfony CLI binary (to ensure the right env and PHP
-# versions are used)
-_{{ .App.HelpName }}_console() {
-  # shellcheck disable=SC2068
-  {{ .CurrentBinaryInvocation }} console $@
-}
-
-_complete_{{ .App.HelpName }}() {
-
-    # Use the default completion for shell redirect operators.
-    for w in '>' '>>' '&>' '<'; do
-        if [[ $w = "${COMP_WORDS[COMP_CWORD-1]}" ]]; then
-            compopt -o filenames
-            COMPREPLY=($(compgen -f -- "${COMP_WORDS[COMP_CWORD]}"))
-            return 0
-        fi
-    done
-
-    for (( i=1; i <= COMP_CWORD; i++ )); do
-        if [[ "${COMP_WORDS[i]}" != -* ]]; then
-            case "${COMP_WORDS[i]}" in
-                console|php|pecl|composer|run|local:run)
-                    _SF_CMD="_{{ .App.HelpName }}_console" _command_offset $i
-                    return
-            esac;
-        fi
-    done
-
-    IFS=$'\n' COMPREPLY=( $(COMP_LINE="${COMP_LINE}" COMP_POINT="${COMP_POINT}" COMP_DEBUG="$COMP_DEBUG" {{ .CurrentBinaryPath }} self:autocomplete) )
-}
-
-complete -F _complete_{{ .App.HelpName }} {{ .App.HelpName }}
+complete -C "{{ .CurrentBinaryPath }} self:autocomplete" {{ .App.HelpName }}

--- a/resources/completion.fish
+++ b/resources/completion.fish
@@ -18,9 +18,7 @@
 # Fish completions for the CLI binary
 #
 # References:
-#   - https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Console/Resources/completion.fish
 #   - https://github.com/posener/complete/blob/master/install/fish.go
-#   - https://github.com/fish-shell/fish-shell/blob/master/share/completions/sudo.fish
 #
 
 function __complete_{{ .App.HelpName }}
@@ -30,13 +28,4 @@ function __complete_{{ .App.HelpName }}
     {{ .CurrentBinaryInvocation }} self:autocomplete
 end
 
-# this wrapper function allows us to call Symfony autocompletion letting it
-# knows how to call the `bin/console` using the Symfony CLI binary (to ensure
-# the right env and PHP versions are used)
-function __complete_{{ .App.HelpName }}_console
-    set -x _SF_CMD "{{ .CurrentBinaryInvocation }}" "console"
-    _sf_console
-end
-
-complete -f -c '{{ .App.HelpName }}' -n "__fish_seen_subcommand_from console" -a '(__complete_{{ .App.HelpName }}_console)' -f
-complete -f -c '{{ .App.HelpName }}' -n "not __fish_seen_subcommand_from console php pecl composer run local:run" -a '(__complete_{{ .App.HelpName }})'
+complete -f -c '{{ .App.HelpName }}' -a '(__complete_{{ .App.HelpName }})'

--- a/resources/completion.zsh
+++ b/resources/completion.zsh
@@ -21,60 +21,8 @@
 # zsh completions for {{ .App.HelpName }}
 #
 # References:
-#   - https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Console/Resources/completion.zsh
 #   - https://github.com/posener/complete/blob/master/install/zsh.go
-#   - https://stackoverflow.com/a/13547531
 #
 
-# this wrapper function allows us to let Symfony knows how to call the
-# `bin/console` using the Symfony CLI binary (to ensure the right env and PHP
-# versions are used)
-_{{ .App.HelpName }}_console() {
-  # shellcheck disable=SC2068
-  {{ .CurrentBinaryInvocation }} console $@
-}
-
-_complete_{{ .App.HelpName }}() {
-    local lastParam flagPrefix requestComp out comp
-    local -a completions
-
-    # The user could have moved the cursor backwards on the command-line.
-    # We need to trigger completion from the $CURRENT location, so we need
-    # to truncate the command-line ($words) up to the $CURRENT location.
-    # (We cannot use $CURSOR as its value does not work when a command is an alias.)
-    words=("${=words[1,CURRENT]}") lastParam=${words[-1]}
-
-    # For zsh, when completing a flag with an = (e.g., {{ .App.HelpName }} -n=<TAB>)
-    # completions must be prefixed with the flag
-    setopt local_options BASH_REMATCH
-    if [[ "${lastParam}" =~ '-.*=' ]]; then
-        # We are dealing with a flag with an =
-        flagPrefix="-P ${BASH_REMATCH}"
-    fi
-
-    # detect if we are in a wrapper command and need to "forward" completion to it
-    for ((i = 1; i <= $#words; i++)); do
-        if [[ "${words[i]}" != -* ]]; then
-              case "${words[i]}" in
-              console|php|pecl|composer|run|local:run)
-                shift words
-                (( CURRENT-- ))
-                _SF_CMD="_{{ .App.HelpName }}_console" _normal
-                return
-            esac;
-        fi
-    done
-
-    while IFS='\n' read -r comp; do
-        if [ -n "$comp" ]; then
-            # We first need to escape any : as part of the completion itself.
-            comp=${comp//:/\\:}
-            completions+=${comp}
-        fi
-    done < <(COMP_LINE="$words" ${words[0]} ${_SF_CMD:-${words[1]}} self:autocomplete)
-
-    # Let inbuilt _describe handle completions
-    eval _describe "completions" completions $flagPrefix
-}
-
-compdef _complete_{{ .App.HelpName }} {{ .App.HelpName }}
+autoload -U +X bashcompinit && bashcompinit
+complete -o nospace -C "{{ .CurrentBinaryInvocation }} self:autocomplete" {{ .App.HelpName }}


### PR DESCRIPTION
This means we don't need to ship complicated Symfony related templates here anymore

Replaces #14