### PR TITLE
Add support for best command in help

### DIFF
--- a/help.go
+++ b/help.go
@@ -148,7 +148,7 @@ func ShowAppHelp(c *Context) error {
 
 // ShowCommandHelp prints help for the given command
 func ShowCommandHelp(ctx *Context, command string) error {
-	if c := ctx.App.Command(command); c != nil {
+	if c := ctx.App.BestCommand(command); c != nil {
 		if c.DescriptionFunc != nil {
 			c.Description = c.DescriptionFunc(c, ctx.App)
 		}

--- a/help_test.go
+++ b/help_test.go
@@ -237,6 +237,29 @@ func TestShowCommandHelp_CommandAliases(t *testing.T) {
 	}
 }
 
+func TestShowCommandHelp_CommandShortcut(t *testing.T) {
+	app := &Application{
+		Commands: []*Command{
+			{
+				Name:     "bar",
+				Category: "foo",
+				Aliases:  []*Alias{{Name: "fb"}},
+				Action: func(ctx *Context) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	output := &bytes.Buffer{}
+	app.Writer = output
+	app.Run([]string{"foo", "help", "f:b"})
+
+	if !strings.Contains(output.String(), "foo:bar") {
+		t.Errorf("expected output to include command name; got: %q", output.String())
+	}
+}
+
 func TestShowCommandHelp_DescriptionFunc(t *testing.T) {
 	app := &Application{
 		Commands: []*Command{


### PR DESCRIPTION
Allows for getting help using the shortcut command as well, ie:

```
# Full command
foo help foo:bar

# Shortcut command (provided that it does not clash with another command)
foo help f:b
```