### PR TITLE
Switch CI to a Go versions matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: Tests
+    strategy:
+      matrix:
+        go:
+          - '1.17'
+          - '1.18'
+          - '1.19'
+          - '1.20'
+          - '1.21'
+          - '1.22'
+          - '1.23'
+          - '1.24'
+    name: Go ${{ matrix.go }} test
     steps:
       -
         name: Checkout
@@ -16,7 +27,7 @@ jobs:
         name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: ${{ matrix.go }}
       - 
         name: Run tests
         run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/symfony-cli/console
 
-go 1.22.4
+go 1.17
 
 require (
 	github.com/agext/levenshtein v1.2.3


### PR DESCRIPTION
This repository is a package, not a end-user application. As such we should not test only a specific Go version as we don't control the version that is going to be in use.