### PR TITLE
fix: fix shell completions script template to remove license

### DIFF
--- a/resources/completion.bash
+++ b/resources/completion.bash
@@ -1,24 +1,29 @@
-# Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
-#
-# This file is part of Symfony CLI project
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-# Bash completions for the CLI binary
-#
-# References:
-#   - https://github.com/posener/complete/blob/master/install/bash.go
-#
+{{- /*
+Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+
+This file is part of Symfony CLI project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/ -}}
+
+{{- /*
+Bash completions for github.com/symfony-cli/console based projects
+
+References:
+  - https://github.com/posener/complete/blob/master/install/bash.go
+*/ -}}
+
+# Bash completions for {{ .App.HelpName }}
 
 complete -C "{{ .CurrentBinaryPath }} self:autocomplete" {{ .App.HelpName }}

--- a/resources/completion.fish
+++ b/resources/completion.fish
@@ -1,25 +1,29 @@
-# Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
-#
-# This file is part of Symfony CLI project
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-# Fish completions for the CLI binary
-#
-# References:
-#   - https://github.com/posener/complete/blob/master/install/fish.go
-#
+{{- /*
+Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+
+This file is part of Symfony CLI project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/ -}}
+
+{{- /*
+Fish completions for github.com/symfony-cli/console based projects
+
+References:
+  - https://github.com/posener/complete/blob/master/install/fish.go
+*/ -}}
+# Fish completions for {{ .App.HelpName }}
 
 function __complete_{{ .App.HelpName }}
     set -lx COMP_LINE (commandline -cp)

--- a/resources/completion.zsh
+++ b/resources/completion.zsh
@@ -1,28 +1,31 @@
+{{- /*
+Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
+
+This file is part of Symfony CLI project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/ -}}
+
+{{- /*
+ZSH completions for github.com/symfony-cli/console based projects
+
+References:
+  - https://github.com/posener/complete/blob/master/install/zsh.go
+*/ -}}
 #compdef {{ .App.HelpName }}
 
-# Copyright (c) 2021-present Fabien Potencier <fabien@symfony.com>
-#
-# This file is part of Symfony CLI project
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-#
 # zsh completions for {{ .App.HelpName }}
-#
-# References:
-#   - https://github.com/posener/complete/blob/master/install/zsh.go
-#
 
 autoload -U +X bashcompinit && bashcompinit
 complete -o nospace -C "{{ .CurrentBinaryInvocation }} self:autocomplete" {{ .App.HelpName }}


### PR DESCRIPTION
Generated content should not mention Symfony CLI but the actuall program name and the template license should use Go template comment instead

fix #30